### PR TITLE
Added url option and fixed host protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ node ./app.js | pino-mongodb [options]
 
     -h, --help                 output usage information
     -V, --version              output the version number
+    -U, --url <url>            complete database url
     -H, --host <address>       database host (localhost)
     -P, --port <number>        database port (27017)
     -d, --db <name>            database name (logs)

--- a/lib/makeUrl.js
+++ b/lib/makeUrl.js
@@ -1,7 +1,12 @@
 'use strict'
 
 module.exports = function makeUrl (program) {
+  if (program.url) return program.url
+
   var url = 'mongodb://'
+  if (program.host.slice(0, 10) === url) {
+    program.host = program.host.slice(10)
+  }
 
   if (program.username && program.password) {
     url += program.username + ':' + program.password + '@'

--- a/pino-mongodb.js
+++ b/pino-mongodb.js
@@ -12,6 +12,7 @@ var makeInsert = require('./lib/insert')
 program
   .version(pkg.version)
   .description(pkg.description)
+  .option('-U, --url <url>', 'complete database url', 'mongodb://localhost:27017/logs')
   .option('-H, --host <address>', 'database host (localhost)', 'localhost')
   .option('-P, --port <number>', 'database port (27017)', 27017)
   .option('-d, --db <name>', 'database name (logs)', 'logs')

--- a/pino-mongodb.js
+++ b/pino-mongodb.js
@@ -12,7 +12,7 @@ var makeInsert = require('./lib/insert')
 program
   .version(pkg.version)
   .description(pkg.description)
-  .option('-U, --url <url>', 'complete database url', 'mongodb://localhost:27017/logs')
+  .option('-U, --url <url>', 'complete database url')
   .option('-H, --host <address>', 'database host (localhost)', 'localhost')
   .option('-P, --port <number>', 'database port (27017)', 27017)
   .option('-d, --db <name>', 'database name (logs)', 'logs')

--- a/test/makeUrl.js
+++ b/test/makeUrl.js
@@ -24,7 +24,27 @@ t.test('makeUrl', t => {
       db: 'logs'
     })
     t.ok(url, 'url ok')
-    t.equal(url, 'mongodb://localhost:27017/logs', 'url should are right')
+    t.equal(url, 'mongodb://localhost:27017/logs', 'url should be right')
+    t.end()
+  })
+
+  t.test('host with protocol', t => {
+    const url = makeUrl({
+      host: 'mongodb://localhost',
+      port: 27017,
+      db: 'logs'
+    })
+    t.ok(url, 'url ok')
+    t.equal(url, 'mongodb://localhost:27017/logs', 'url should be right')
+    t.end()
+  })
+
+  t.test('complete url', t => {
+    const url = makeUrl({
+      url: 'mongodb://test:27017/db'
+    })
+    t.ok(url, 'url ok')
+    t.equal(url, 'mongodb://test:27017/db', 'url should be right')
     t.end()
   })
 


### PR DESCRIPTION
With this pr now the user can pass directly the complete url to the module, it can be useful if the complete url is stored somewhere such as inside `process.env`.

In addition can happen that a user pass the host with the protocol and the mongo client will throw, this pr fixes also that issue.

cc @mcollina 