### PR TITLE
using native Date datatype

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -5,6 +5,7 @@ module.exports = function log (data) {
 
   try {
     log = JSON.parse(data)
+    if (log.time) log.time = new Date(log.time)
   } catch (e) {
     log = {
       msg: data


### PR DESCRIPTION
Normally, logging with pino gives a timestamp of form `{time: 1542563971325}`. When this is inserted directly to Mongo, it's inserted as the `double` data type.

Modifying this to insert the `time` field as a [native BSON `Date` type](https://docs.mongodb.com/manual/reference/bson-types/#document-bson-type-date) gives some neat datetime functions (also it looks neater in the shell/compass ‾\\\_(ツ)_/‾ ). `double` and `Date` both take 64 bits anyway so I don't see any reason why not to insert it as `Date`.