### PR TITLE
add an option (-u) to use the new unified topology for mongodb

### DIFF
--- a/pino-mongodb.js
+++ b/pino-mongodb.js
@@ -16,6 +16,7 @@ program
   .option('-c, --collection <name>', 'database collection', 'logs')
   .option('-o, --stdout', 'output inserted documents into stdout', false)
   .option('-e, --errors', 'output insertion errors into stderr', false)
+  .option('-u, --unified', 'use mongodb unified topology', false)
   .parse(process.argv)
 
 const mongoUrl = (program.args[0] || 'mongodb://localhost:27017/logs')
@@ -41,8 +42,11 @@ function handleConnection (e, mClient) {
   })
 }
 
+const options = { useNewUrlParser: true }
+if (program.unified) { options.useUnifiedTopology = true }
+
 MongoClient.connect(
   mongoUrl,
-  { useNewUrlParser: true },
+  options,
   handleConnection
 )


### PR DESCRIPTION
This pull request add a new option for the command line:
`-u, --unified  -  use mongodb unified topology`
So the mongoclient can be started with the `useUnifiedTopology` option

http://mongodb.github.io/node-mongodb-native/3.3/reference/unified-topology/