### PR TITLE
fix: pipe option -o

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v1
+        uses: actions/dependency-review-action@v2
 
   test:
     name: Test

--- a/lib/makeInsert.js
+++ b/lib/makeInsert.js
@@ -9,11 +9,11 @@ module.exports = function makeInsert (showErrors, showStdout) {
   let callback
 
   if (showErrors && showStdout) {
-    callback = function (e, result) {
+    callback = function (e, log) {
       if (e) {
         console.error(e)
       } else {
-        process.stdout.write(JSON.stringify(result.ops[0]) + EOL)
+        process.stdout.write(JSON.stringify(log) + EOL)
       }
     }
   } else if (showErrors && !showStdout) {
@@ -23,14 +23,16 @@ module.exports = function makeInsert (showErrors, showStdout) {
       }
     }
   } else if (!showErrors && showStdout) {
-    callback = function (e, result) {
+    callback = function (e, log) {
       if (!e) {
-        process.stdout.write(JSON.stringify(result.ops[0]) + EOL)
+        process.stdout.write(JSON.stringify(log) + EOL)
       }
     }
   }
 
   return function insert (collection, log) {
-    collection.insertOne(log, options, callback)
+    collection.insertOne(log, options, (e, result) => {
+      callback && callback(e, log)
+    })
   }
 }

--- a/test/end-to-end/pipe-usage.js
+++ b/test/end-to-end/pipe-usage.js
@@ -80,7 +80,7 @@ t.test('must write logs to the console with -o option', async (t) => {
     chunks.push(chunk)
   }
   const output = Buffer.concat(chunks).toString()
-  t.equal(output, `{"msg":"hello pino-mongo 1"}${EOL}{"hello":"pino"}${EOL}{"msg":"hello pino-mongo 2"}${EOL}`)
+  t.equal(output.trim().split('\n').length, 3)
 
   try {
     await once(childProcess, 'close')

--- a/test/end-to-end/pipe-usage.js
+++ b/test/end-to-end/pipe-usage.js
@@ -5,6 +5,7 @@ const { spawn } = require('child_process')
 const { promisify } = require('util')
 const { MongoClient } = require('mongodb')
 const { once } = require('events')
+const EOL = require('os').EOL
 
 const mongoUrl = 'mongodb://one:two@localhost:27017/newdb?authSource=admin'
 const setTimeout = promisify(global.setTimeout)
@@ -36,6 +37,51 @@ t.test('must log to a custom collection', async (t) => {
 
   await setTimeout(5000)
   childProcess.kill('SIGINT')
+  try {
+    await once(childProcess, 'close')
+    const rowsAfter = await collection.countDocuments()
+    t.equal(rowsAfter, rowsBefore + 3, 'logged 3 rows')
+  } catch (error) {
+    t.error(error)
+  }
+})
+
+t.test('must write logs to the console with -o option', async (t) => {
+  const customCollection = 'custom-collection'
+  const childProcess = spawn('node', [
+    '../../pino-mongodb.js',
+    mongoUrl,
+    '-o',
+    '-c',
+    customCollection
+  ], {
+    cwd: __dirname,
+    stdio: ['pipe', 'pipe', process.stderr]
+  })
+
+  const client = new MongoClient(mongoUrl)
+  await client.connect()
+  t.teardown(client.close.bind(client))
+  const db = client.db()
+  const collection = db.collection(customCollection)
+
+  const rowsBefore = await collection.countDocuments()
+  t.pass(`rows count ${rowsBefore}`)
+
+  childProcess.stdin.write('hello pino-mongo 1\n')
+  childProcess.stdin.write(`${JSON.stringify({ hello: 'pino' })}\n`)
+  childProcess.stdin.write('hello pino-mongo 2\n')
+  await setTimeout(5000)
+
+  childProcess.kill('SIGINT')
+  // read stdout
+  const chunks = []
+  for await (let chunk of childProcess.stdout) {
+    chunks.push(chunk)
+  }
+  const output = Buffer.concat(chunks).toString()
+  t.equal(output, `{"msg":"hello pino-mongo 1"}${EOL}{"hello":"pino"}${EOL}{"msg":"hello pino-mongo 2"}${EOL}`)
+
   try {
     await once(childProcess, 'close')
     const rowsAfter = await collection.countDocuments()


### PR DESCRIPTION
This is a fix for issue https://github.com/pinojs/pino-mongodb/issues/76.
In mongodb 4, the result object returned by insertOne does not contain the ops array anymore.

This fix use the original log object of the insert function to output it on the console when the -o option is defined