### PR TITLE
Exit pino-mongodb when stdin is closed

### DIFF
--- a/lib/makeInsert.js
+++ b/lib/makeInsert.js
@@ -30,9 +30,10 @@ module.exports = function makeInsert (showErrors, showStdout) {
     }
   }
 
-  return function insert (collection, log) {
+  return function insert (collection, log, cliCallback) {
     collection.insertOne(log, options, (e, result) => {
       callback && callback(e, log)
+      cliCallback && cliCallback()
     })
   }
 }


### PR DESCRIPTION
fix #13, There is 2 case to take into account :

- The `process.stdin` is closed when pino-mongodb is idle, this is detected by the 'close' event, in that case, we can close the mongodb connection and exit the program immediately.
- There is one or more pending insert when the process.stdin is closed, to avoid loosing logs, we have to wait until the inserts are done before closing the database connection. To track the async inserts, I use a counter, when it reach 0 and the stdin is closed, we can close the database connection and exit the program.

I'm really not sure if keeping track of the unresolved promises using a counter is the best way to handle that. @mcollina is that an acceptable solution ?

