### PR TITLE
Fix - mongodb punycode warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const transport = pino.transport({
 pino(transport)
 ```
 
-The `mongoOptions` is provided to the the standard mongodb client. All the available options are described on [its official documentation](https://mongodb.github.io/node-mongodb-native/4.1/interfaces/MongoClientOptions.html).
+The `mongoOptions` is provided to the the standard mongodb client. All the available options are described on [its official documentation](https://mongodb.github.io/node-mongodb-native/6.4/interfaces/MongoClientOptions.html)
 
 Note that you may encouter missing logs in special cases: it dependes on data and mongo's version. Please checkout the [mongodb limitation](https://docs.mongodb.com/manual/reference/limits/) official documentation.  
 For example on MongoDB 4:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "carrier": "^0.3",
     "commander": "^10.0",
-    "mongodb": "^4.7",
+    "mongodb": "^6.4",
     "muri": "^1.3",
     "pino-abstract-transport": "^1.0.0"
   },

--- a/trial/assert.js
+++ b/trial/assert.js
@@ -3,7 +3,7 @@ const t = require('assert').strict
 
 async function main () {
   const url = process.argv.slice(2, 3)[0]
-  const conn = await MongoClient.connect(url, { useUnifiedTopology: true })
+  const conn = await MongoClient.connect(url)
   const db = conn.db('admin')
   const logs = db.collection('logs')
 


### PR DESCRIPTION
Updated MongoDB to version 6.4, adjusted MongoClient connection options, and revised README to match. Addresses the punycode deprecation warning and ensures up-to-date compatibility.